### PR TITLE
Fix login tokens & add Google Sheets export

### DIFF
--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -1,15 +1,22 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createFormSubmission, getFormSubmissions } from "@/lib/database"
+import { exportSubmissionToSheet } from "@/lib/google-sheets"
 
 export async function POST(request: NextRequest) {
   try {
     const submissionData = await request.json()
     const savedSubmission = await createFormSubmission(submissionData)
 
-    // TODO: Trigger Google Sheets export if configured
-    // if (submissionData.googleSheetUrl) {
-    //   await exportToGoogleSheets(savedSubmission, submissionData.googleSheetUrl)
-    // }
+    if (submissionData.googleSheetUrl) {
+      try {
+        await exportSubmissionToSheet(
+          savedSubmission,
+          submissionData.googleSheetUrl
+        )
+      } catch (err) {
+        console.error("Google Sheets export failed:", err)
+      }
+    }
 
     return NextResponse.json(savedSubmission)
   } catch (error) {

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -36,8 +36,8 @@ export function LoginForm() {
         throw new Error(data.error || "Login failed")
       }
 
-      // Store tokens and user data
-      AuthClient.setTokens(data.tokens.accessToken, data.tokens.refreshToken)
+      // Store token and user data
+      AuthClient.setTokens(data.token)
       AuthClient.setUser(data.user)
 
       // Redirect to dashboard

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -4,10 +4,14 @@ export class AuthClient {
   private static REFRESH_TOKEN_KEY = "pilana_refresh_token"
   private static USER_KEY = "pilana_user"
 
-  static setTokens(accessToken: string, refreshToken: string) {
+  static setTokens(accessToken: string, refreshToken?: string) {
     if (typeof window !== "undefined") {
       localStorage.setItem(this.TOKEN_KEY, accessToken)
-      localStorage.setItem(this.REFRESH_TOKEN_KEY, refreshToken)
+      if (refreshToken) {
+        localStorage.setItem(this.REFRESH_TOKEN_KEY, refreshToken)
+      } else {
+        localStorage.removeItem(this.REFRESH_TOKEN_KEY)
+      }
     }
   }
 

--- a/lib/google-sheets.ts
+++ b/lib/google-sheets.ts
@@ -81,3 +81,23 @@ export class GoogleSheetsService {
     return match ? match[1] : null
   }
 }
+
+export async function exportSubmissionToSheet(
+  submission: { submitted_at: string; data: any },
+  sheetUrl: string,
+  range = "Sheet1!A1"
+) {
+  const service = GoogleSheetsService.getInstance()
+  const spreadsheetId = service.extractSpreadsheetId(sheetUrl)
+  if (!spreadsheetId) {
+    console.warn(`Invalid Google Sheet URL: ${sheetUrl}`)
+    return
+  }
+  const values = [[submission.submitted_at, JSON.stringify(submission.data)]]
+  try {
+    await service.appendToSheet(spreadsheetId, range, values)
+  } catch (error) {
+    console.error("Failed to export submission to Google Sheets:", error)
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
- store refresh token only when provided
- update login form to use `token` from API
- add Google Sheets submission exporter and invoke it in submissions route

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run type-check` *(fails to find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68494310f58c832fb7c472c44433938d