### PR TITLE
Enable optional Google Sheets export for submissions

### DIFF
--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -1,15 +1,22 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createFormSubmission, getFormSubmissions } from "@/lib/database"
+import { exportSubmissionToSheet } from "@/lib/google-sheets"
 
 export async function POST(request: NextRequest) {
   try {
     const submissionData = await request.json()
     const savedSubmission = await createFormSubmission(submissionData)
 
-    // TODO: Trigger Google Sheets export if configured
-    // if (submissionData.googleSheetUrl) {
-    //   await exportToGoogleSheets(savedSubmission, submissionData.googleSheetUrl)
-    // }
+    if (submissionData.googleSheetUrl) {
+      try {
+        await exportSubmissionToSheet(
+          submissionData.googleSheetUrl,
+          savedSubmission
+        )
+      } catch (error) {
+        console.error("Error exporting to Google Sheets:", error)
+      }
+    }
 
     return NextResponse.json(savedSubmission)
   } catch (error) {

--- a/lib/google-sheets.ts
+++ b/lib/google-sheets.ts
@@ -81,3 +81,18 @@ export class GoogleSheetsService {
     return match ? match[1] : null
   }
 }
+
+export async function exportSubmissionToSheet(
+  googleSheetUrl: string,
+  submission: any,
+  range = "Sheet1!A1"
+) {
+  const service = GoogleSheetsService.getInstance()
+  const spreadsheetId = service.extractSpreadsheetId(googleSheetUrl)
+  if (!spreadsheetId) {
+    throw new Error("Invalid Google Sheet URL")
+  }
+
+  const values = [[new Date().toISOString(), JSON.stringify(submission)]]
+  return service.appendToSheet(spreadsheetId, range, values)
+}

--- a/vercel.json
+++ b/vercel.json
@@ -8,9 +8,5 @@
   },
   "github": {
     "silent": true
-  },
-  "projectSettings": {
-    "name": "pilanaapp",
-    "framework": "nextjs"
   }
 }


### PR DESCRIPTION
## Summary
- add `exportSubmissionToSheet` helper to append submissions to a sheet
- trigger Google Sheet export from submissions API when `googleSheetUrl` is provided
- remove unsupported `projectSettings` block from `vercel.json`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68494f4b3e94832f9a43262ed2ddf007